### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on: # yamllint disable-line rule:truthy
   - push
 


### PR DESCRIPTION
Potential fix for [https://github.com/theholocron/media-explorer/security/code-scanning/9](https://github.com/theholocron/media-explorer/security/code-scanning/9)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow, so it applies to all jobs unless overridden. For most CI workflows that only need to check out code and run tests, `contents: read` is sufficient. If any job requires more permissions, it can override the setting at the job level. In this case, none of the jobs appear to require more than read access, so adding the following at the top level is appropriate:

```yaml
permissions:
  contents: read
```

This should be added after the `name:` and before the `on:` block (i.e., after line 1 and before line 3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
